### PR TITLE
fix(Link): Make `href` optional

### DIFF
--- a/src/components/link.props.json
+++ b/src/components/link.props.json
@@ -88,7 +88,9 @@
     }
   },
   "href": {
-    "defaultValue": null,
+    "defaultValue": {
+      "value": ""
+    },
     "description": "",
     "name": "href",
     "declarations": [
@@ -97,7 +99,7 @@
         "name": "TypeLiteral"
       }
     ],
-    "required": true,
+    "required": false,
     "type": {
       "name": "string"
     },

--- a/src/components/link.tsx
+++ b/src/components/link.tsx
@@ -3,12 +3,12 @@ import React, { forwardRef, type ElementRef, type ComponentProps } from "react";
 const defaultTag = "a";
 
 export type LinkProps = Omit<ComponentProps<typeof defaultTag>, "href"> & {
-    href: string;
+    href?: string;
 }
 
 export const Link = forwardRef<
   ElementRef<typeof defaultTag>,
     LinkProps
->((props, ref) => <a {...props} ref={ref} />);
+>(({href = '', ...props}, ref) => <a {...props} href={href} ref={ref} />);
 
 Link.displayName = "Link";


### PR DESCRIPTION
Right now we don't have an ability to prevent a component from rendering if the required prop isn't provided. To work-around this the `href` is made optional again but in the future we'd need a more general solution to handle required props.